### PR TITLE
WoE: add a new effect for Knightapult

### DIFF
--- a/server/game/GameActions/PutIntoPlayAction.js
+++ b/server/game/GameActions/PutIntoPlayAction.js
@@ -52,7 +52,8 @@ class PutIntoPlayAction extends CardGameAction {
                 context.ability.isCardPlayed() &&
                 (this.deploy ||
                     card.hasKeyword('deploy') ||
-                    card.checkConditions('entersPlayAnywhere', context)) &&
+                    card.checkConditions('entersPlayAnywhere', context) ||
+                    player.anyEffect('creaturesEnterPlayAnywhereAndReady')) &&
                 player.creaturesInPlay.length > 1
             ) {
                 choices.push('Deploy Left');
@@ -187,7 +188,11 @@ class PutIntoPlayAction extends CardGameAction {
                     card.updateEffectContexts();
                 }
 
-                if (!this.ready && !card.checkConditions('entersPlayReady', context)) {
+                if (
+                    !this.ready &&
+                    !card.checkConditions('entersPlayReady', context) &&
+                    !player.anyEffect('creaturesEnterPlayAnywhereAndReady')
+                ) {
                     card.exhaust();
                 }
 

--- a/server/game/cards/06-WoE/Knightapult.js
+++ b/server/game/cards/06-WoE/Knightapult.js
@@ -5,47 +5,13 @@ class Knightapult extends Card {
     setupCardAbilities(ability) {
         this.action({
             effect: 'have the next friendly creature enter play anywhere in your battleline, ready',
-            gameAction: [
-                ability.actions.forRemainderOfTurn((context) => ({
-                    when: {
-                        onAbilityInitiated: (event) =>
-                            event.player === context.player &&
-                            event.card.type === 'creature' &&
-                            event.context.ability.title === 'Play this creature'
-                    },
-                    location: 'any',
-                    multipleTrigger: false,
-                    gameAction: ability.actions.cardLastingEffect((context) => ({
-                        targetLocation: 'play area',
-                        target: context.event.card,
-                        effect: [
-                            ability.effects.entersPlayAnywhere(),
-                            ability.effects.entersPlayReady(),
-                            ability.effects.addKeyword({ deploy: 1 })
-                        ]
-                    })),
-                    effect: 'have {1} enter play anywhere in their battleline, ready',
-                    effectArgs: (event) => [event.card]
-                })),
-                ability.actions.forRemainderOfTurn((context) => ({
-                    when: {
-                        onCardPlayed: (event) =>
-                            event.player === context.player && event.card.type === 'creature'
-                    },
-                    multipleTrigger: false,
-                    triggeredAbilityType: 'interrupt',
-                    gameAction: ability.actions.cardLastingEffect((context) => ({
-                        targetLocation: 'play area',
-                        target: context.event.card,
-                        effect: [
-                            ability.effects.entersPlayAnywhere(),
-                            ability.effects.entersPlayReady()
-                        ]
-                    })),
-                    effect: 'have {1} enter play anywhere in their battleline, ready',
-                    effectArgs: (event) => [event.card]
-                }))
-            ]
+            gameAction: ability.actions.forRemainderOfTurn({
+                until: {
+                    onCardEntersPlay: (event) => event.card.type === 'creature'
+                },
+                targetController: 'self',
+                effect: ability.effects.creaturesEnterPlayAnywhereAndReady()
+            })
         });
     }
 }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -133,7 +133,9 @@ const Effects = {
     stopHouseChoice: (house) => EffectBuilder.player.flexible('stopHouseChoice', house),
     skipStep: (step) => EffectBuilder.player.static('skipStep', step),
     opponentCardsCannotLeaveArchives: (card) =>
-        EffectBuilder.player.static('opponentCardsCannotLeaveArchives', card)
+        EffectBuilder.player.static('opponentCardsCannotLeaveArchives', card),
+    creaturesEnterPlayAnywhereAndReady: () =>
+        EffectBuilder.player.static('creaturesEnterPlayAnywhereAndReady')
 };
 
 module.exports = Effects;

--- a/test/server/cards/06-WoE/Knightapult.spec.js
+++ b/test/server/cards/06-WoE/Knightapult.spec.js
@@ -29,12 +29,24 @@ describe('Knightapult', function () {
                 expect(this.player1).toHavePromptButton('Deploy Right');
             });
 
-            xit('to be ready', function () {
+            it('to be ready', function () {
+                this.player1.clickPrompt('Deploy Left');
+                this.player1.clickCard(this.flaxia);
                 expect(this.holdfast.exhausted).toBe(false);
             });
-        });
 
-        it('should only apply to the first creature played');
+            it('should only apply to the first creature played', function () {
+                this.player1.clickPrompt('Deploy Left');
+                this.player1.clickCard(this.flaxia);
+
+                this.player1.clickCard(this.berinon);
+                this.player1.clickPrompt('Play this creature');
+                expect(this.player1).toHavePromptButton('Left');
+                expect(this.player1).toHavePromptButton('Right');
+                expect(this.player1).not.toHavePromptButton('Deploy Left');
+                expect(this.player1).not.toHavePromptButton('Deploy Right');
+            });
+        });
     });
 
     it("should cause Gebuk's replacement to be deployable and ready");


### PR DESCRIPTION
I made a new player effect and had it expire as soon as a creature is played. Not sure if this is perfect but it seems to work for the simple case at least!

I think the problem before was that the onPlay events don't actually fire until after the deploy prompts are decided on.

cc: @alifeee

Issue: keyteki#3186